### PR TITLE
Cr1/ft/collections

### DIFF
--- a/CoolFluentHelpers/CoolFluentHelpers.csproj
+++ b/CoolFluentHelpers/CoolFluentHelpers.csproj
@@ -9,7 +9,7 @@
     <Title>CoolFluentHelpers</Title>
     <Copyright>Copyright (c) 2023 Noe de Paz &lt;ndepaz2016@gmail.com&gt;</Copyright>
     <RepositoryUrl>https://github.com/ndepaz/PeacefulCoding</RepositoryUrl>
-    <PackageTags>v3.12.12</PackageTags>
+    <PackageTags>v3.13.12</PackageTags>
     <PackageReleaseNotes>initial</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/ndepaz/PeacefulCoding</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>programming_fun.png</PackageIcon>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>3.12.12</Version>
+    <Version>3.13.12</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CoolFluentHelpers/CoolFluentHelpers.csproj
+++ b/CoolFluentHelpers/CoolFluentHelpers.csproj
@@ -9,7 +9,7 @@
     <Title>CoolFluentHelpers</Title>
     <Copyright>Copyright (c) 2023 Noe de Paz &lt;ndepaz2016@gmail.com&gt;</Copyright>
     <RepositoryUrl>https://github.com/ndepaz/PeacefulCoding</RepositoryUrl>
-    <PackageTags>v1.1.6</PackageTags>
+    <PackageTags>v3.12.12</PackageTags>
     <PackageReleaseNotes>initial</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/ndepaz/PeacefulCoding</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>programming_fun.png</PackageIcon>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.1.6</Version>
+    <Version>3.12.12</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CoolFluentHelpers/ExpressionBuilder.cs
+++ b/CoolFluentHelpers/ExpressionBuilder.cs
@@ -45,10 +45,7 @@ namespace CoolFluentHelpers
         {
             return new ExpressionBuilder<T>();
         }
-        public void AddExpression(ICompareExpression<T> compareExpression)
-        {
-            compareExpressions.Add(compareExpression);
-        }
+
         public Dictionary<string, QueryOperation[]> GetPropertiesSupportedOperations()
         {
             var result = new Dictionary<string, QueryOperation[]>();
@@ -68,7 +65,7 @@ namespace CoolFluentHelpers
         }
         public static IExpressionBuilderForCollection<T> ForCollections()
         {
-            return new ExpressionBuilderForCollection<T>();
+            return ExpressionBuilderForCollection<T>.Create();
         }
 
         public ICompareExpression<T> ForProperty<TValue>(Expression<Func<T, TValue>> propertyExpression, string displayName = null)
@@ -351,9 +348,16 @@ namespace CoolFluentHelpers
 
         public IResult<Expression<Func<T, bool>>> AsExpressionResult()
         {
-            _expressionComparison.AddExpressionsList(WithValue((TValue)_value));
+            try
+            {
+                _expressionComparison.AddExpressionsList(WithValue((TValue)_value));
 
-            return _expressionComparison.AsExpression();
+                return _expressionComparison.AsExpression();
+            }
+            catch (Exception ex)
+            {
+                return Result.Failure<Expression<Func<T, bool>>>(ex.Message);
+            }
         }
     }
 

--- a/CoolFluentHelpers/ExpressionBuilder.cs
+++ b/CoolFluentHelpers/ExpressionBuilder.cs
@@ -45,7 +45,10 @@ namespace CoolFluentHelpers
         {
             return new ExpressionBuilder<T>();
         }
-
+        public void AddExpression(ICompareExpression<T> compareExpression)
+        {
+            compareExpressions.Add(compareExpression);
+        }
         public Dictionary<string, QueryOperation[]> GetPropertiesSupportedOperations()
         {
             var result = new Dictionary<string, QueryOperation[]>();
@@ -63,7 +66,10 @@ namespace CoolFluentHelpers
             }
             return result;
         }
-
+        public IExpressionBuilder<TValue> ForCollection<TValue>(Expression<Func<T, IEnumerable<TValue>>> propertyExpression, string displayName = null)
+        {
+            return ExpressionBuilderForCollection<T, TValue>.Create(propertyExpression, displayName);
+        }
         public ICompareExpression<T> ForProperty<TValue>(Expression<Func<T, TValue>> propertyExpression, string displayName = null)
         {
             if (displayName is null)
@@ -99,6 +105,8 @@ namespace CoolFluentHelpers
         {
             return compareExpressions.Where(x => x.PropertyDisplayName == propertyDisplayName).ToList();
         }
+
+
     }
 
     public interface IExpressionBuilder<T>

--- a/CoolFluentHelpers/ExpressionBuilder.cs
+++ b/CoolFluentHelpers/ExpressionBuilder.cs
@@ -34,9 +34,9 @@ namespace CoolFluentHelpers
     public class ExpressionBuilder<T> : IExpressionBuilder<T>
     {
 
-        private List<ICompareExpression<T>> compareExpressions = new();
+        protected List<ICompareExpression<T>> compareExpressions = new();
 
-        private ExpressionBuilder()
+        protected ExpressionBuilder()
         {
 
         }
@@ -66,7 +66,7 @@ namespace CoolFluentHelpers
             }
             return result;
         }
-        public IExpressionBuilder<TValue> ForCollection<TValue>(Expression<Func<T, IEnumerable<TValue>>> propertyExpression, string displayName = null)
+        public IForCollectionBuilder<T, TValue> ForCollection<TValue>(Expression<Func<T, IEnumerable<TValue>>> propertyExpression, string displayName = null)
         {
             return ExpressionBuilderForCollection<T, TValue>.Create(propertyExpression, displayName);
         }

--- a/CoolFluentHelpers/ExpressionBuilderForCollection.cs
+++ b/CoolFluentHelpers/ExpressionBuilderForCollection.cs
@@ -9,35 +9,341 @@ using System.Threading.Tasks;
 
 namespace CoolFluentHelpers
 {
-    //IExpressionBuilder<TModel>
-    public class ExpressionBuilderForCollection<TModel,TValue> : IExpressionBuilderForCollection<TModel,TValue>
+    //IExpressionBuilder<RootModel>
+    public class ExpressionBuilderForCollection<RootModel,TValue> : IExpressionBuilderForCollection<RootModel,TValue>
     {
-        private readonly List<ICompareExpression<TModel>> _expressions = new();
-        private Expression<Func<TModel, IEnumerable<TValue>>> expression;
+        private readonly List<ICompareExpression<RootModel>> _expressions = new();
+        private Expression<Func<RootModel, IEnumerable<TValue>>> expression;
 
-        public ExpressionBuilderForCollection(Expression<Func<TModel, IEnumerable<TValue>>> expression, string displayName)
+        public ExpressionBuilderForCollection(Expression<Func<RootModel, IEnumerable<TValue>>> expression, string displayName)
         {
             this.expression = expression;
             DisplayName = displayName;
         }
 
-        public IReadOnlyList<ICompareExpression<TModel>> Expressions => _expressions.AsReadOnly();
+        public IReadOnlyList<ICompareExpression<RootModel>> Expressions => _expressions.AsReadOnly();
 
         public string DisplayName { get; }
 
-        public static IExpressionBuilder<TValue> Create<TModel, TValue>(Expression<Func<TModel, IEnumerable<TValue>>> propertyExpression, string displayName = null)
+        public static IForCollectionBuilder<RootModel, TValue> Create<RootModel, TValue>(Expression<Func<RootModel, IEnumerable<TValue>>> collectionSelector, string displayName = null)
         {
             if (displayName is null)
             {
-                displayName = propertyExpression.Body.ToString();
+                displayName = collectionSelector.Body.ToString();
             }
             //TODO: to reimplement a version of the builder which can be used for collections
-            return ExpressionBuilder<TValue>.Create();
+            return ForCollectionBuilder<RootModel,TValue>.Create(collectionSelector, displayName);
         }
     }
 
+    public class ForCollectionBuilder<RootModel,T> : IForCollectionBuilder<RootModel, T>
+    {
+        protected List<ICompareExpressionForCollection<RootModel, T>> compareExpressions = new();
+        private Expression<Func<RootModel, IEnumerable<T>>> collectionSelector;
+        private readonly string rootDisplayName;
+
+        public ForCollectionBuilder(Expression<Func<RootModel, IEnumerable<T>>> propertyExpression, string rootDisplayName)
+        {
+            this.collectionSelector = propertyExpression;
+            this.rootDisplayName = rootDisplayName;
+        }
+
+        public static ForCollectionBuilder<RootModel,T> Create(Expression<Func<RootModel, IEnumerable<T>>> collectionSelector, string rootDisplayName)
+        {
+            return new ForCollectionBuilder<RootModel,T>(collectionSelector,rootDisplayName);
+        }
+
+        public IResult<ICompareExpressionForCollection<RootModel, T>> FindByPropertyByDisplayName(string propertyDisplayName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IReadOnlyList<ICompareExpressionForCollection<RootModel, T>> FindPropertiesByDisplayName(string propertyDisplayName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IResult<ICompareExpressionForCollection<RootModel, T>> FirstPropertyByDisplayName(string propertyDisplayName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICompareExpressionForCollection<RootModel, T> WithProperty<TValue>(Expression<Func<T, TValue>> propertyExpression, string displayName = null)
+        {
+            if (displayName is null)
+            {
+                displayName = $"{rootDisplayName} {propertyExpression.Body.ToString()}";
+            }
+
+            var expressionComparison = ExpressionComparisonForCollection<RootModel,T, TValue>.Create(collectionSelector,displayName, propertyExpression);
+
+            compareExpressions.Add(expressionComparison);
+
+            return expressionComparison;
+        }
+
+        public Dictionary<string, QueryOperation[]> GetPropertiesSupportedOperations()
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public interface IForCollectionBuilder<RootModel, T>
+    {
+        ICompareExpressionForCollection<RootModel, T> WithProperty<TValue>(Expression<Func<T, TValue>> propertyExpression, string displayName = null);
+    }
+
+    public interface ICompareExpressionForCollection<RootModel, T>
+    {
+        ICompareValueForCollection<RootModel, T> Compare(QueryOperation queryOperation);
+        ICompareValueForCollection<RootModel, T> CompareWithDefault();
+        ICompareExpressionForCollection<RootModel, T> OnlyIf(bool condition);
+    }
+
+    public class ExpressionComparisonForCollection<RootModel,T, TValue> : ICompareExpressionForCollection<RootModel, T>
+    {
+        internal Expression<Func<T, TValue>> PropertyExpression { get; }
+        public string PropertyDisplayName { get; }
+
+        internal QueryOperation QueryOperation { get; private set; }
+
+        internal TValue Value { get; private set; }
+
+        internal bool IsAnd { get; private set; } = true;
+
+        private bool _isOnlyIf = true;
+
+        private List<Expression<Func<T, bool>>> _expressionAndList = new();
+        private List<Expression<Func<T, bool>>> _expressionOrList = new();
+        private Expression<Func<RootModel, IEnumerable<T>>> collectionSelector;
+
+        private ExpressionComparisonForCollection(Expression<Func<T, TValue>> propertyExpression, string propertyDisplayName)
+        {
+            PropertyExpression = propertyExpression;
+            PropertyDisplayName = propertyDisplayName;
+
+        }
+
+        private ExpressionComparisonForCollection(Expression<Func<T, TValue>> propertyExpression, string propertyDisplayName, TValue value, QueryOperation queryOperation)
+        {
+            PropertyExpression = propertyExpression;
+            PropertyDisplayName = propertyDisplayName;
+            QueryOperation = queryOperation;
+            Value = value;
+        }
+
+        public ExpressionComparisonForCollection(Expression<Func<RootModel, IEnumerable<T>>> collectionSelector, Expression<Func<T, TValue>> propertyExpression, string propertyDisplayName)
+        {
+            this.collectionSelector = collectionSelector;
+            PropertyExpression = propertyExpression;
+            PropertyDisplayName = propertyDisplayName;
+        }
+
+        internal static ExpressionComparisonForCollection<RootModel,T, TValue> Copy(ExpressionComparisonForCollection<RootModel,T, TValue> expressionComparison)
+        {
+            return new ExpressionComparisonForCollection<RootModel,T, TValue>(
+                expressionComparison.PropertyExpression,
+                expressionComparison.PropertyDisplayName,
+                expressionComparison.Value,
+                expressionComparison.QueryOperation)
+                .ChangeCurrentAndOrClause(expressionComparison.IsAnd);
+        }
+
+        internal static ExpressionComparisonForCollection<RootModel,T, TValue> Create(Expression<Func<RootModel, IEnumerable<T>>> collectionSelector, string propertyDisplayName, Expression<Func<T, TValue>> propertyExpression)
+        {
+            return new ExpressionComparisonForCollection<RootModel,T, TValue>(collectionSelector,propertyExpression, propertyDisplayName);
+        }
+
+        public ICompareValueForCollection<RootModel,T> CompareWithDefault()
+        {
+            return ExpressionValueForCollection<RootModel,T, TValue>.Create(collectionSelector,this);
+        }
+
+        public ICompareValueForCollection<RootModel, T> Compare(QueryOperation queryOperation)
+        {
+            QueryOperation = queryOperation;
+
+            return ExpressionValueForCollection<RootModel,T, TValue>.Create(collectionSelector,this);
+        }
+
+        private ExpressionComparisonForCollection<RootModel,T, TValue> ChangeCurrentAndOrClause(bool useAnd)
+        {
+            IsAnd = useAnd;
+
+            return this;
+        }
+
+        internal ExpressionComparisonForCollection<RootModel,T, TValue> ChangeCurrentToAnd()
+        {
+            return ChangeCurrentAndOrClause(true);
+        }
+
+        internal ExpressionComparisonForCollection<RootModel,T, TValue> ChangeCurrentToOr()
+        {
+            return ChangeCurrentAndOrClause(false);
+        }
+
+        internal void SetValue(TValue value)
+        {
+            this.Value = value;
+        }
+
+        public ICompareExpressionForCollection<RootModel, T> OnlyIf(bool condition)
+        {
+            _isOnlyIf = condition;
+
+            return this;
+        }
+
+        private bool MeetOnlyCondition()
+        {
+            return _isOnlyIf;
+        }
+
+        internal IResult<Expression<Func<T, bool>>> AsExpression()
+        {
+            if (!MeetOnlyCondition())
+            {
+                return Result.Failure<Expression<Func<T, bool>>>("OnlyIf condition was not met");
+            }
+
+            var andExpressionsList = _expressionAndList;
+
+            var orExpressionsList = _expressionOrList;
+
+            return ExpressionCombiner.CombineExpressions(andExpressionsList, orExpressionsList);
+        }
+
+        internal ICompareExpressionForCollection<RootModel, T> AddExpressionsToAndList(ExpressionComparisonForCollection<RootModel,T, TValue> expressionComparison)
+        {
+
+            var expression = ExpressionBuilder.BuildPredicate(expressionComparison.PropertyExpression, expressionComparison.QueryOperation, expressionComparison.Value);
+
+            _expressionAndList.Add(expression);
+
+            return this;
+        }
+
+        internal ICompareExpressionForCollection<RootModel, T> AddExpressionsToOrList(ExpressionComparisonForCollection<RootModel,T, TValue> expressionComparison)
+        {
+            var expression = ExpressionBuilder.BuildPredicate(expressionComparison.PropertyExpression, expressionComparison.QueryOperation, expressionComparison.Value);
+
+            _expressionOrList.Add(expression);
+
+            return this;
+        }
+
+        public Type GetPropertyType()
+        {
+            return typeof(TValue);
+        }
+
+        public QueryOperation GetQueryOperation()
+        {
+            return QueryOperation;
+        }
+    }
+
+    public interface ICompareAndOrForCollection<RootModel,T>
+    {
+        public ICompareExpressionForCollection<RootModel, T> OrElse();
+        public ICompareExpressionForCollection<RootModel, T> AndAlso();
+        /// <summary>
+        /// Combine the current expression with the next expression using the clause
+        /// </summary>
+        /// <param name="clause"></param>
+        /// <returns></returns>
+        ICompareExpressionForCollection<RootModel, T> CombineWith(QueryClause clause);
+        /// <summary>
+        /// Returns the combined expressions as a single expression
+        /// </summary>
+        /// <returns></returns>
+        public Result<Expression<Func<RootModel, bool>>> AsExpressionResult();
+    }
+    public interface ICompareValueForCollection<RootModel, T>
+    {
+        ICompareAndOrForCollection<RootModel, T> WithAnyValue(object value);
+    }
+    public class ExpressionValueForCollection<RootModel,T, TValue> : ICompareValueForCollection<RootModel,T>, ICompareAndOrForCollection<RootModel, T>
+    {
+        private object _value;
+        private readonly Expression<Func<RootModel, IEnumerable<T>>> collectionSelector;
+
+        private ExpressionValueForCollection(Expression<Func<RootModel, IEnumerable<T>>> collectionSelector, ExpressionComparisonForCollection<RootModel,T, TValue> expressionComparison)
+        {
+            this.collectionSelector = collectionSelector;
+            _expressionComparison = expressionComparison;
+        }
+
+        private ExpressionComparisonForCollection<RootModel,T, TValue> _expressionComparison { get; }
+
+        internal static ExpressionValueForCollection<RootModel,T, TValue> Create(Expression<Func<RootModel, IEnumerable<T>>> collectionSelector, ExpressionComparisonForCollection<RootModel,T, TValue> expressionComparison)
+        {
+            return new ExpressionValueForCollection<RootModel,T, TValue>(collectionSelector,expressionComparison);
+        }
+
+        internal ExpressionComparisonForCollection<RootModel,T, TValue> WithValue(TValue value)
+        {
+            _expressionComparison.SetValue(value);
+
+            return ExpressionComparisonForCollection<RootModel,T, TValue>.Copy(_expressionComparison);
+        }
+
+        public ICompareAndOrForCollection<RootModel, T> WithAnyValue(object value)
+        {
+            _value = value;
+
+            return this;
+        }
+
+        public ICompareExpressionForCollection<RootModel, T> CombineWith(QueryClause clause)
+        {
+            if (clause is QueryClause.And)
+            {
+                return AndAlso();
+            }
+
+            return OrElse();
+        }
+
+        public ICompareExpressionForCollection<RootModel, T> OrElse()
+        {
+            _expressionComparison.ChangeCurrentToOr();
+
+            return _expressionComparison.AddExpressionsToOrList(WithValue((TValue)_value));
+        }
+
+        public ICompareExpressionForCollection<RootModel, T> AndAlso()
+        {
+            _expressionComparison.ChangeCurrentToAnd();
+
+            return _expressionComparison.AddExpressionsToAndList(WithValue((TValue)_value));
+        }
+
+        public Result<Expression<Func<RootModel, bool>>> AsExpressionResult()
+        {
+            if (_expressionComparison.IsAnd)
+            {
+                AndAlso();
+            }
+            else
+            {
+                OrElse();
+            }
+            var result = _expressionComparison.AsExpression();
+            if (result.IsFailure)
+            {
+                return Result.Failure<Expression<Func<RootModel, bool>>>(result.Error);
+            }
+
+            return Result.Success(PredicateBuilder.BuildCollectionPredicate(collectionSelector, result.Value, false));
+        }
+    }
+
+
+
     public interface IExpressionBuilderForCollection<Model, TCollection>
     {
-        static abstract IExpressionBuilder<TValue> Create<TModel, TValue>(Expression<Func<TModel, IEnumerable<TValue>>> propertyExpression, string displayName = null);
+        static abstract IForCollectionBuilder<RootModel, TValue> Create<RootModel, TValue>(Expression<Func<RootModel, IEnumerable<TValue>>> propertyExpression, string displayName = null);
     }
 }

--- a/CoolFluentHelpers/ExpressionBuilderForCollection.cs
+++ b/CoolFluentHelpers/ExpressionBuilderForCollection.cs
@@ -9,88 +9,91 @@ using System.Threading.Tasks;
 
 namespace CoolFluentHelpers
 {
-    //IExpressionBuilder<RootModel>
-    public class ExpressionBuilderForCollection<RootModel,TValue> : IExpressionBuilderForCollection<RootModel,TValue>
+    public class ExpressionBuilderForCollection<RootModel> : IExpressionBuilderForCollection<RootModel>
     {
-        private readonly List<ICompareExpression<RootModel>> _expressions = new();
-        private Expression<Func<RootModel, IEnumerable<TValue>>> expression;
-
-        public ExpressionBuilderForCollection(Expression<Func<RootModel, IEnumerable<TValue>>> expression, string displayName)
+        public ExpressionBuilderForCollection()
         {
-            this.expression = expression;
-            DisplayName = displayName;
         }
 
-        public IReadOnlyList<ICompareExpression<RootModel>> Expressions => _expressions.AsReadOnly();
-
-        public string DisplayName { get; }
-
-        public static IForCollectionBuilder<RootModel, TValue> Create<RootModel, TValue>(Expression<Func<RootModel, IEnumerable<TValue>>> collectionSelector, string displayName = null)
+        internal static IExpressionBuilderForCollection<RootModel1> Create<RootModel1>()
         {
-            if (displayName is null)
-            {
-                displayName = collectionSelector.Body.ToString();
-            }
-            //TODO: to reimplement a version of the builder which can be used for collections
-            return ForCollectionBuilder<RootModel,TValue>.Create(collectionSelector, displayName);
+            return new ExpressionBuilderForCollection<RootModel1>();
+        }
+
+        public IForCollectionBuilder<RootModel,T> ForCollection<T>(Expression<Func<RootModel, IEnumerable<T>>> collectionSelector, string rootDisplayName)
+        {
+            var forCollectionBuilder = ForCollectionBuilder<RootModel,T>.Create(collectionSelector, rootDisplayName);
+            
+            return forCollectionBuilder;
         }
     }
 
-    public class ForCollectionBuilder<RootModel,T> : IForCollectionBuilder<RootModel, T>
+    public class ForCollectionBuilder<RootModel,TCollectionModel> : IForCollectionBuilder<RootModel, TCollectionModel>
     {
-        protected List<ICompareExpressionForCollection<RootModel, T>> compareExpressions = new();
-        private Expression<Func<RootModel, IEnumerable<T>>> collectionSelector;
+        protected List<ICompareExpressionForCollection<RootModel>> compareExpressions = new();
+        private Expression<Func<RootModel, IEnumerable<TCollectionModel>>> collectionSelector;
         private readonly string rootDisplayName;
 
-        public ForCollectionBuilder(Expression<Func<RootModel, IEnumerable<T>>> propertyExpression, string rootDisplayName)
+        public ForCollectionBuilder(Expression<Func<RootModel, IEnumerable<TCollectionModel>>> propertyExpression, string rootDisplayName)
         {
             this.collectionSelector = propertyExpression;
             this.rootDisplayName = rootDisplayName;
         }
 
-        public static ForCollectionBuilder<RootModel,T> Create(Expression<Func<RootModel, IEnumerable<T>>> collectionSelector, string rootDisplayName)
+        internal static ForCollectionBuilder<RootModel, TCollectionModel> Create(Expression<Func<RootModel, IEnumerable<TCollectionModel>>> collectionSelector, string rootDisplayName)
         {
-            return new ForCollectionBuilder<RootModel,T>(collectionSelector,rootDisplayName);
+            return new ForCollectionBuilder<RootModel,TCollectionModel>(collectionSelector,rootDisplayName);
         }
 
-        public IResult<ICompareExpressionForCollection<RootModel, T>> FindByPropertyByDisplayName(string propertyDisplayName)
+        public IReadOnlyList<ICompareExpressionForCollection<RootModel>> FindPropertiesByDisplayName(string propertyDisplayName)
         {
-            throw new NotImplementedException();
+            return compareExpressions.Where(x => x.PropertyDisplayName == propertyDisplayName).ToList();
         }
 
-        public IReadOnlyList<ICompareExpressionForCollection<RootModel, T>> FindPropertiesByDisplayName(string propertyDisplayName)
+        public Result<ICompareExpressionForCollection<RootModel>> FirstPropertyByDisplayName(string propertyDisplayName)
         {
-            throw new NotImplementedException();
-        }
+            var expressionComparison = compareExpressions.FirstOrDefault(x => x.PropertyDisplayName == propertyDisplayName);
 
-        public IResult<ICompareExpressionForCollection<RootModel, T>> FirstPropertyByDisplayName(string propertyDisplayName)
-        {
-            throw new NotImplementedException();
+            return Result.SuccessIf(expressionComparison is not null, expressionComparison, "Property was not found");
         }
-
-        public ICompareExpressionForCollection<RootModel, T> WithProperty<TValue>(Expression<Func<T, TValue>> propertyExpression, string displayName = null)
+        public ICompareExpressionForCollection<RootModel> ForProperty<TValue>(Expression<Func<TCollectionModel, TValue>> propertyExpression, string displayName = null)
         {
             if (displayName is null)
             {
                 displayName = $"{rootDisplayName} {propertyExpression.Body.ToString()}";
             }
 
-            var expressionComparison = ExpressionComparisonForCollection<RootModel,T, TValue>.Create(collectionSelector,displayName, propertyExpression);
+            var expressionComparison = ExpressionComparisonForCollection<RootModel, TCollectionModel, TValue>.Create(collectionSelector, displayName, propertyExpression);
 
             compareExpressions.Add(expressionComparison);
 
             return expressionComparison;
         }
-
         public Dictionary<string, QueryOperation[]> GetPropertiesSupportedOperations()
         {
-            throw new NotImplementedException();
+            var result = new Dictionary<string, QueryOperation[]>();
+
+            foreach (var expression in compareExpressions)
+            {
+                if (result.ContainsKey(expression.PropertyDisplayName))
+                {
+                    result[expression.PropertyDisplayName] = result[expression.PropertyDisplayName].Append(expression.GetQueryOperation()).ToArray();
+                }
+                else
+                {
+                    result.Add(expression.PropertyDisplayName, new[] { expression.GetQueryOperation() });
+                }
+            }
+            return result;
         }
     }
 
-    public interface IForCollectionBuilder<RootModel, T>
+    public interface IForCollectionBuilder<RootModel, TCollectionModel>
     {
-        ICompareExpressionForCollection<RootModel, T> WithProperty<TValue>(Expression<Func<T, TValue>> propertyExpression, string displayName = null);
+        IReadOnlyList<ICompareExpressionForCollection<RootModel>> FindPropertiesByDisplayName(string propertyDisplayName);
+        Result<ICompareExpressionForCollection<RootModel>> FirstPropertyByDisplayName(string propertyDisplayName);
+        ICompareExpressionForCollection<RootModel> ForProperty<TValue>(Expression<Func<TCollectionModel, TValue>> propertyExpression, string displayName = null);
+        Dictionary<string, QueryOperation[]> GetPropertiesSupportedOperations();
     }
 
     public class ClauseWithExpression<T>
@@ -109,14 +112,17 @@ namespace CoolFluentHelpers
         }
     }
 
-    public interface ICompareExpressionForCollection<RootModel, T>
+    public interface ICompareExpressionForCollection<RootModel>
     {
-        ICompareValueForCollection<RootModel, T> Compare(QueryOperation queryOperation);
-        ICompareValueForCollection<RootModel, T> CompareWithDefault();
-        ICompareExpressionForCollection<RootModel, T> OnlyIf(bool condition);
+        string PropertyDisplayName { get; }
+
+        ICompareValueForCollection<RootModel> Compare(QueryOperation queryOperation);
+        ICompareValueForCollection<RootModel> CompareWithDefault();
+        ICompareExpressionForCollection<RootModel> OnlyIf(bool condition);
+        public QueryOperation GetQueryOperation();
     }
 
-    public class ExpressionComparisonForCollection<RootModel,T, TValue> : ICompareExpressionForCollection<RootModel, T>
+    public class ExpressionComparisonForCollection<RootModel,T, TValue> : ICompareExpressionForCollection<RootModel>
     {
         internal Expression<Func<T, TValue>> PropertyExpression { get; }
         public string PropertyDisplayName { get; }
@@ -129,8 +135,8 @@ namespace CoolFluentHelpers
 
         private bool _isOnlyIf = true;
 
-        private List<ClauseWithExpression<T>> _expressionAndList = new();
-        //private List<Expression<Func<T, bool>>> _expressionOrList = new();
+        private List<ClauseWithExpression<T>> _expressionList = new();
+
         private Expression<Func<RootModel, IEnumerable<T>>> collectionSelector;
 
         private ExpressionComparisonForCollection(Expression<Func<T, TValue>> propertyExpression,
@@ -168,12 +174,12 @@ namespace CoolFluentHelpers
             return new ExpressionComparisonForCollection<RootModel,T, TValue>(collectionSelector,propertyExpression, propertyDisplayName);
         }
 
-        public ICompareValueForCollection<RootModel,T> CompareWithDefault()
+        public ICompareValueForCollection<RootModel> CompareWithDefault()
         {
             return ExpressionValueForCollection<RootModel,T, TValue>.Create(collectionSelector,this);
         }
 
-        public ICompareValueForCollection<RootModel, T> Compare(QueryOperation queryOperation)
+        public ICompareValueForCollection<RootModel> Compare(QueryOperation queryOperation)
         {
             CurrentQueryOperation = queryOperation;
 
@@ -204,7 +210,7 @@ namespace CoolFluentHelpers
             this.Value = value;
         }
 
-        public ICompareExpressionForCollection<RootModel, T> OnlyIf(bool condition)
+        public ICompareExpressionForCollection<RootModel> OnlyIf(bool condition)
         {
             _isOnlyIf = condition;
 
@@ -223,31 +229,20 @@ namespace CoolFluentHelpers
                 return Result.Failure<Expression<Func<T, bool>>>("OnlyIf condition was not met");
             }
 
-            var andExpressionsList = _expressionAndList;
-
-            //var orExpressionsList = _expressionOrList;
+            var andExpressionsList = _expressionList;
 
             return ExpressionCombiner.CombineExpressionsInOrder(andExpressionsList);
         }
 
-        internal ICompareExpressionForCollection<RootModel, T> AddExpressionsToList(ExpressionComparisonForCollection<RootModel,T, TValue> expressionComparison)
+        internal ICompareExpressionForCollection<RootModel> AddExpressionsList(ExpressionComparisonForCollection<RootModel,T, TValue> expressionComparison)
         {
 
             var expression = ExpressionBuilder.BuildPredicate(expressionComparison.PropertyExpression, expressionComparison.CurrentQueryOperation, expressionComparison.Value);
 
-            _expressionAndList.Add(ClauseWithExpression<T>.Create(expression, CurrentQueryClause));
+            _expressionList.Add(ClauseWithExpression<T>.Create(expression, CurrentQueryClause));
 
             return this;
         }
-
-        //internal ICompareExpressionForCollection<RootModel, T> AddExpressionsToOrList(ExpressionComparisonForCollection<RootModel,T, TValue> expressionComparison)
-        //{
-        //    var expression = ExpressionBuilder.BuildPredicate(expressionComparison.PropertyExpression, expressionComparison.CurrentQueryOperation, expressionComparison.Value);
-
-        //    _expressionAndList.Add(expression);
-
-        //    return this;
-        //}
 
         public Type GetPropertyType()
         {
@@ -260,28 +255,28 @@ namespace CoolFluentHelpers
         }
     }
 
-    public interface ICompareAndOrForCollection<RootModel,T>
+    public interface ICompareAndOrForCollection<RootModel>
     {
-        public ICompareExpressionForCollection<RootModel, T> OrElse();
-        public ICompareExpressionForCollection<RootModel, T> AndAlso();
+        public ICompareExpressionForCollection<RootModel> OrElse();
+        public ICompareExpressionForCollection<RootModel> AndAlso();
         /// <summary>
         /// Combine the current expression with the next expression using the clause
         /// </summary>
         /// <param name="clause"></param>
         /// <returns></returns>
-        ICompareExpressionForCollection<RootModel, T> CombineWith(QueryClause clause);
+        ICompareExpressionForCollection<RootModel> CombineWith(QueryClause clause);
         /// <summary>
         /// Returns the combined expressions as a single expression
         /// </summary>
         /// <returns></returns>
         public Result<Expression<Func<RootModel, bool>>> AsExpressionResult();
     }
-    public interface ICompareValueForCollection<RootModel, T>
+    public interface ICompareValueForCollection<RootModel>
     {
-        ICompareAndOrForCollection<RootModel, T> WithAnyValue(object value);
+        ICompareAndOrForCollection<RootModel> WithAnyValue(object value);
     }
     
-    public class ExpressionValueForCollection<RootModel,T, TValue> : ICompareValueForCollection<RootModel,T>, ICompareAndOrForCollection<RootModel, T>
+    public class ExpressionValueForCollection<RootModel,T, TValue> : ICompareValueForCollection<RootModel>, ICompareAndOrForCollection<RootModel>
     {
         private object _value;
         private readonly Expression<Func<RootModel, IEnumerable<T>>> collectionSelector;
@@ -306,38 +301,36 @@ namespace CoolFluentHelpers
             return ExpressionComparisonForCollection<RootModel,T, TValue>.StoreComparisonAndQueryInfo(_expressionComparison);
         }
 
-        public ICompareAndOrForCollection<RootModel, T> WithAnyValue(object value)
+        public ICompareAndOrForCollection<RootModel> WithAnyValue(object value)
         {
 
             _value = value;
-            //SetToOriginClause();
-
+            
             return this;
         }
 
-        public ICompareExpressionForCollection<RootModel, T> CombineWith(QueryClause clause)
+        public ICompareExpressionForCollection<RootModel> CombineWith(QueryClause clause)
         {
             if (clause is QueryClause.And)
             {
                 return AndAlso();
             }
-
+                                                                                                                   
             return OrElse();
         }
 
-        public ICompareExpressionForCollection<RootModel, T> OrElse()
+        public ICompareExpressionForCollection<RootModel> OrElse()
         {
+            var instance = _expressionComparison.AddExpressionsList(WithValue((TValue)_value));
 
-
-            var instance = _expressionComparison.AddExpressionsToList(WithValue((TValue)_value));
             _expressionComparison.ChangeCurrentClause(QueryClause.Or);
 
             return instance;
         }
 
-        public ICompareExpressionForCollection<RootModel, T> AndAlso()
+        public ICompareExpressionForCollection<RootModel> AndAlso()
         {
-            var instance = _expressionComparison.AddExpressionsToList(WithValue((TValue)_value));
+            var instance = _expressionComparison.AddExpressionsList(WithValue((TValue)_value));
 
             _expressionComparison.ChangeCurrentClause(QueryClause.And);
 
@@ -347,7 +340,7 @@ namespace CoolFluentHelpers
 
         public Result<Expression<Func<RootModel, bool>>> AsExpressionResult()
         {
-            _expressionComparison.AddExpressionsToList(WithValue((TValue)_value));
+            _expressionComparison.AddExpressionsList(WithValue((TValue)_value));
 
             var result = _expressionComparison.AsExpression();
 
@@ -360,8 +353,8 @@ namespace CoolFluentHelpers
         }
     }
 
-    public interface IExpressionBuilderForCollection<Model, TCollection>
+    public interface IExpressionBuilderForCollection<RootModel>
     {
-        static abstract IForCollectionBuilder<RootModel, TValue> Create<RootModel, TValue>(Expression<Func<RootModel, IEnumerable<TValue>>> propertyExpression, string displayName = null);
+        IForCollectionBuilder<RootModel,T> ForCollection<T>(Expression<Func<RootModel, IEnumerable<T>>> collectionSelector, string rootDisplayName = null);
     }
 }

--- a/CoolFluentHelpers/ExpressionBuilderForCollection.cs
+++ b/CoolFluentHelpers/ExpressionBuilderForCollection.cs
@@ -1,0 +1,43 @@
+﻿using CSharpFunctionalExtensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CoolFluentHelpers
+{
+    //IExpressionBuilder<TModel>
+    public class ExpressionBuilderForCollection<TModel,TValue> : IExpressionBuilderForCollection<TModel,TValue>
+    {
+        private readonly List<ICompareExpression<TModel>> _expressions = new();
+        private Expression<Func<TModel, IEnumerable<TValue>>> expression;
+
+        public ExpressionBuilderForCollection(Expression<Func<TModel, IEnumerable<TValue>>> expression, string displayName)
+        {
+            this.expression = expression;
+            DisplayName = displayName;
+        }
+
+        public IReadOnlyList<ICompareExpression<TModel>> Expressions => _expressions.AsReadOnly();
+
+        public string DisplayName { get; }
+
+        public static IExpressionBuilder<TValue> Create<TModel, TValue>(Expression<Func<TModel, IEnumerable<TValue>>> propertyExpression, string displayName = null)
+        {
+            if (displayName is null)
+            {
+                displayName = propertyExpression.Body.ToString();
+            }
+            //TODO: to reimplement a version of the builder which can be used for collections
+            return ExpressionBuilder<TValue>.Create();
+        }
+    }
+
+    public interface IExpressionBuilderForCollection<Model, TCollection>
+    {
+        static abstract IExpressionBuilder<TValue> Create<TModel, TValue>(Expression<Func<TModel, IEnumerable<TValue>>> propertyExpression, string displayName = null);
+    }
+}

--- a/CoolFluentHelpers/ExpressionBuilderForCollection.cs
+++ b/CoolFluentHelpers/ExpressionBuilderForCollection.cs
@@ -265,7 +265,8 @@ namespace CoolFluentHelpers
         /// Returns the combined expressions as a single expression
         /// </summary>
         /// <returns></returns>
-        public Result<Expression<Func<RootModel, bool>>> AsExpressionResult();
+        public Result<Expression<Func<RootModel, bool>>> AsAnyExpressionResult();
+        public Result<Expression<Func<RootModel, bool>>> AsAllExpressionResult();
     }
     public interface ICompareValueForCollection<RootModel>
     {
@@ -334,7 +335,7 @@ namespace CoolFluentHelpers
         
         }
 
-        public Result<Expression<Func<RootModel, bool>>> AsExpressionResult()
+        public Result<Expression<Func<RootModel, bool>>> AsAnyExpressionResult()
         {
 
             try
@@ -349,6 +350,27 @@ namespace CoolFluentHelpers
                 }
 
                 return Result.Success(PredicateBuilder.BuildCollectionPredicate(collectionSelector, result.Value, false));
+            }
+            catch (Exception e)
+            {
+                return Result.Failure<Expression<Func<RootModel, bool>>>(e.Message);
+            }
+        }
+
+        public Result<Expression<Func<RootModel, bool>>> AsAllExpressionResult()
+        {
+            try
+            {
+                _expressionComparison.AddExpressionsList(WithValue((TValue)_value));
+
+                var result = _expressionComparison.AsExpression();
+
+                if (result.IsFailure)
+                {
+                    return Result.Failure<Expression<Func<RootModel, bool>>>(result.Error);
+                }
+
+                return Result.Success(PredicateBuilder.BuildCollectionPredicate(collectionSelector, result.Value, true));
             }
             catch (Exception e)
             {

--- a/CoolFluentHelpers/PredicateBuilder.cs
+++ b/CoolFluentHelpers/PredicateBuilder.cs
@@ -30,6 +30,22 @@ namespace CoolFluentHelpers
             // Construct the lambda expression and return it
             return Expression.Lambda<Func<Model, bool>>(binaryExp, parameterExp);
         }
+        public static Expression<Func<T, bool>> BuildCollectionPredicate<T, TElement>(
+                Expression<Func<T, IEnumerable<TElement>>> collectionSelector,
+                Expression<Func<TElement, bool>> elementPredicate,
+                bool all = false)
+        {
+            var param = Expression.Parameter(typeof(T), "x");
+
+            // Use `Any` or `All` based on the parameter "all"
+            var method = all ? "All" : "Any";
+            MethodInfo methodInfo = typeof(Enumerable).GetMethods().First(m => m.Name == method && m.GetParameters().Length == 2).MakeGenericMethod(typeof(TElement));
+
+            var collection = Expression.Invoke(collectionSelector, param);
+            var call = Expression.Call(methodInfo, collection, elementPredicate);
+
+            return Expression.Lambda<Func<T, bool>>(call, param);
+        }
     }
 
     internal static class ExpressionBuilder

--- a/CoolUnitTests/BasicTests.cs
+++ b/CoolUnitTests/BasicTests.cs
@@ -724,9 +724,7 @@ namespace CoolUnitTests
         [MemberData(nameof(PeopleWithPets))]
         public void Collections_test(List<Person> people)
         {
-
             //arrange
-
             var builder = ExpressionBuilder<Person>.Create();
             
             var result = builder
@@ -741,11 +739,17 @@ namespace CoolUnitTests
                 .OrElse()
                 .Compare(QueryOperation.EndsWith)
                 .WithAnyValue("3")
+                .AndAlso()
+                .Compare(QueryOperation.Equals)
+                .WithAnyValue("Fido4")
+                .OrElse()
+                .Compare(QueryOperation.EndsWith)
+                .WithAnyValue("1")
                 .AsExpressionResult();
 
             result.IsSuccess.Should().BeTrue();
 
-            Expression<Func<Person, bool>> expression = x => x.Pets.Any(y=>y.Name.StartsWith("Fi") && y.Name.Contains("2") || y.Name.EndsWith("3"));
+            Expression<Func<Person, bool>> expression = x => x.Pets.Any(y=>y.Name.StartsWith("Fi") && y.Name.Contains("2") || y.Name.EndsWith("3") && y.Name.Equals("Fido4") || y.Name.EndsWith("1") );
             
             result.Value.Should().BeEquivalentTo(expression);
             

--- a/CoolUnitTests/BasicTests.cs
+++ b/CoolUnitTests/BasicTests.cs
@@ -744,7 +744,7 @@ namespace CoolUnitTests
                 .OrElse()
                 .Compare(QueryOperation.EndsWith)
                 .WithAnyValue("1")
-                .AsExpressionResult();
+                .AsAnyExpressionResult();
 
             result.IsSuccess.Should().BeTrue();
 
@@ -772,11 +772,38 @@ namespace CoolUnitTests
                 .OnlyIf(true)
                 .Compare(QueryOperation.EndsWith)
                 .WithAnyValue("4")
-                .AsExpressionResult();
+                .AsAnyExpressionResult();
 
             result.IsSuccess.Should().BeTrue();
 
             Expression<Func<Person, bool>> stronglyTypedVersionExpression = x => x.Pets.Any(y => y.Name.EndsWith("4") );
+
+            result.Value.Should().BeEquivalentTo(stronglyTypedVersionExpression);
+
+            var list = people.AsQueryable().Where(result.Value);
+
+            var list2 = people.AsQueryable().Where(stronglyTypedVersionExpression);
+
+            list.Should().BeEquivalentTo(list2);
+        }
+
+        [Theory]
+        [MemberData(nameof(PeopleWithPets))]
+        public void single_collection_expression_all(List<Person> people)
+        {
+            var builder = ExpressionBuilder<Person>.ForCollections();
+
+            var result = builder
+                .ForCollection(x => x.Pets)
+                .ForProperty(x => x.Name)
+                .OnlyIf(true)
+                .Compare(QueryOperation.StartsWith)
+                .WithAnyValue("Fi")
+                .AsAllExpressionResult();
+
+            result.IsSuccess.Should().BeTrue();
+
+            Expression<Func<Person, bool>> stronglyTypedVersionExpression = x => x.Pets.All(y => y.Name.StartsWith("Fi"));
 
             result.Value.Should().BeEquivalentTo(stronglyTypedVersionExpression);
 
@@ -803,7 +830,7 @@ namespace CoolUnitTests
                 .CombineWith(QueryClause.And)
                 .Compare(QueryOperation.StartsWith)
                 .WithAnyValue("Fido")
-                .AsExpressionResult();
+                .AsAnyExpressionResult();
 
             result.IsSuccess.Should().BeTrue();
 
@@ -834,7 +861,7 @@ namespace CoolUnitTests
                 .CombineWith(QueryClause.Or)
                 .Compare(QueryOperation.StartsWith)
                 .WithAnyValue("Fido")
-                .AsExpressionResult();
+                .AsAnyExpressionResult();
 
             result.IsSuccess.Should().BeTrue();
 
@@ -919,7 +946,7 @@ namespace CoolUnitTests
                 .OnlyIf(true)
                 .Compare(QueryOperation.GreaterThan)
                 .WithAnyValue("4")
-                .AsExpressionResult();
+                .AsAnyExpressionResult();
 
             result.IsSuccess.Should().BeFalse();
         }
@@ -945,7 +972,7 @@ namespace CoolUnitTests
             var result = property2
                 .CompareWithDefault()
                 .WithAnyValue("Fido1")
-                .AsExpressionResult();
+                .AsAnyExpressionResult();
 
             //assert
 
@@ -973,7 +1000,7 @@ namespace CoolUnitTests
                 .ForProperty(x => x.Name)
                 .Compare(QueryOperation.GreaterThan)
                 .WithAnyValue(18)
-                .AsExpressionResult();
+                .AsAnyExpressionResult();
 
             result.IsSuccess.Should().BeFalse();
         }
@@ -990,7 +1017,7 @@ namespace CoolUnitTests
                 .OnlyIf(false)
                 .Compare(QueryOperation.GreaterThan)
                 .WithAnyValue(18)
-                .AsExpressionResult();
+                .AsAnyExpressionResult();
 
             result.IsSuccess.Should().BeFalse();
         }

--- a/CoolUnitTests/BasicTests.cs
+++ b/CoolUnitTests/BasicTests.cs
@@ -721,7 +721,7 @@ namespace CoolUnitTests
             yield return new object[] { list };
         }
         [Theory]
-        [MemberData(nameof(People))]
+        [MemberData(nameof(PeopleWithPets))]
         public void Collections_test(List<Person> people)
         {
 
@@ -731,14 +731,30 @@ namespace CoolUnitTests
             
             var result = builder
                 .ForCollection(x=>x.Pets)
-                .ForProperty(x => x.Name)
-                //.OnlyIf(hasAPet == "does have a pet")
-                .Compare(QueryOperation.GreaterThan)
-                .WithAnyValue(18)
-                .CombineWith(QueryClause.And)
-                .Compare(QueryOperation.LessThan)
-                .WithAnyValue(80)
+                .WithProperty(x => x.Name)
+                .OnlyIf(true)
+                .Compare(QueryOperation.StartsWith)
+                .WithAnyValue("Fi")
+                .AndAlso()
+                .Compare(QueryOperation.Contains)
+                .WithAnyValue("2")
+                .OrElse()
+                .Compare(QueryOperation.EndsWith)
+                .WithAnyValue("3")
                 .AsExpressionResult();
+
+            result.IsSuccess.Should().BeTrue();
+
+            Expression<Func<Person, bool>> expression = x => x.Pets.Any(y=>y.Name.StartsWith("Fi") && y.Name.Contains("2") || y.Name.EndsWith("3"));
+            
+            result.Value.Should().BeEquivalentTo(expression);
+            
+            var list = people.AsQueryable().Where(result.Value);
+
+            var list2 = people.AsQueryable().Where(expression);
+
+            list.Should().BeEquivalentTo(list2);
+
         }
 
 

--- a/CoolUnitTests/BasicTests.cs
+++ b/CoolUnitTests/BasicTests.cs
@@ -696,8 +696,51 @@ namespace CoolUnitTests
 
             _output.WriteLine(json);
         }
+        public static IEnumerable<object[]> PeopleWithPets()
+        {
+            var mom = new Person("Jane", DateTime.Now.AddYears(-30));
+            mom.Pets.Add(new Pet("Fido1"));
+
+            mom.FavoriteNumber = 7;
+
+            var son = new Person("Bob", DateTime.Now.AddYears(-15));
+            son.Pets.Add(new Pet("Fido2"));
+
+            son.FavoriteNumber = 14;
+
+            var daughter = new Person("Elisa", DateTime.Now.AddYears(-8));
+            daughter.Pets.Add(new Pet("Fido3"));
+
+            daughter.FavoriteNumber = 8;
+
+            mom.AddFamily(son, daughter);
+            mom.Pets.Add(new Pet("Fido4"));
+
+            var list = new List<Person> { mom, son, daughter };
+
+            yield return new object[] { list };
+        }
+        [Theory]
+        [MemberData(nameof(People))]
+        public void Collections_test(List<Person> people)
+        {
+
+            //arrange
+
+            var builder = ExpressionBuilder<Person>.Create();
+            
+            var result = builder
+                .ForCollection(x=>x.Pets)
+                .ForProperty(x => x.Name)
+                //.OnlyIf(hasAPet == "does have a pet")
+                .Compare(QueryOperation.GreaterThan)
+                .WithAnyValue(18)
+                .CombineWith(QueryClause.And)
+                .Compare(QueryOperation.LessThan)
+                .WithAnyValue(80)
+                .AsExpressionResult();
+        }
+
+
     }
-
-
-
 }

--- a/CoolUnitTests/Person.cs
+++ b/CoolUnitTests/Person.cs
@@ -16,6 +16,7 @@ namespace CoolUnitTests
         public DateTime Born { get; set; }
         public int Age => CalculateAge(Born);
         public int? FavoriteNumber { get; set; }
+        public List<Pet> Pets { get; set; } = new();
         public static int CalculateAge(DateTime birthdate)
         {
             int age = DateTime.Today.Year - birthdate.Year;
@@ -37,6 +38,18 @@ namespace CoolUnitTests
         }
     }
 
+    public class Pet
+    {
+        public Pet()
+        {
+            
+        }
+        public string Name { get; }
 
+        public Pet(string name)
+        {
+            Name = name;
+        }
+    }
 
 }

--- a/CoolUnitTests/Person.cs
+++ b/CoolUnitTests/Person.cs
@@ -50,6 +50,8 @@ namespace CoolUnitTests
         {
             Name = name;
         }
+
+
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PeacefulCoding
 
-You can use Expression Maker to allow you to create dynamic Expressions.
+You can use ExpressionBuilder to allow you to create dynamic Expressions.
 
 This is useful when you need to pass arbitrary comparisons to a query while keeping a stronlgy typed approach.
 
@@ -52,7 +52,7 @@ var result = builder
     .OnlyIf(true)
     .Compare(QueryOperation.EndsWith)
     .WithAnyValue("4")
-    .AsExpressionResult();
+    .AsAnyExpressionResult();
 
 result.IsSuccess.Should().BeTrue();
 
@@ -67,7 +67,8 @@ var list2 = people.AsQueryable().Where(stronglyTypedVersionExpression);
 list.Should().BeEquivalentTo(list2);
 ```
 
-You can chain different combinations of clauses and operations to create complex expressions.
+### You can chain different combinations of clauses and operations to create complex expressions.
+
 ```csharp
 var builder = ExpressionBuilder<Person>.ForCollections();
             
@@ -89,7 +90,7 @@ var result = builder
     .OrElse()
     .Compare(QueryOperation.EndsWith)
     .WithAnyValue("1")
-    .AsExpressionResult();
+    .AsAnyExpressionResult();
 
 result.IsSuccess.Should().BeTrue();
 
@@ -107,8 +108,11 @@ list.Should().BeEquivalentTo(list2);
 
 ## Release Notes
 
-### v3.12.12
-- Added support for IEnumerables
+### v3.13.12
+- Added support for Collections allowing you to create expressions for multiple properties under the same collection.
+  - In addition adds support for the following operations under collections:
+    - AsAnyExpressionResult
+    - AsAllExpressionResult
 - Corrected the order of operations by implementing the necessary changes in the affected code.
 - Conducted comprehensive testing to verify the fix and ensure proper functionality.
 - With this correction, the package now executes operations according to the correct order, ensuring accurate results and expected behavior.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There is still more to come, but for now you can use it to create simple express
 
 QueryOperation are meant to be controlled by the developer as there isn't a easy way to narrow them by property type just yet.
 
-Now, we support IEnumerables.
+Now, IEnumerables expressions are supported.
 
 ## Simple usage in UnitTest form
 Visit the unit tests project to learn more

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There is still more to come, but for now you can use it to create simple express
 
 QueryOperation are meant to be controlled by the developer as there isn't a easy way to narrow them by property type just yet.
 
-IEnumerables are not yet supported, but will be soon.
+Now, we support IEnumerables.
 
 ## Simple usage in UnitTest form
 Visit the unit tests project to learn more
@@ -40,6 +40,78 @@ var expression = expressionResult.Value;
 expression.Should().BeEquivalentTo(expectedExpression);
 
 ```
+
+## Simple usage in UnitTest form with collections
+
+```csharp
+var builder = ExpressionBuilder<Person>.ForCollections();
+
+var result = builder
+    .ForCollection(x => x.Pets)
+    .ForProperty(x => x.Name)
+    .OnlyIf(true)
+    .Compare(QueryOperation.EndsWith)
+    .WithAnyValue("4")
+    .AsExpressionResult();
+
+result.IsSuccess.Should().BeTrue();
+
+Expression<Func<Person, bool>> stronglyTypedVersionExpression = x => x.Pets.Any(y => y.Name.EndsWith("4") );
+
+result.Value.Should().BeEquivalentTo(stronglyTypedVersionExpression);
+
+var list = people.AsQueryable().Where(result.Value);
+
+var list2 = people.AsQueryable().Where(stronglyTypedVersionExpression);
+
+list.Should().BeEquivalentTo(list2);
+```
+
+You can chain different combinations of clauses and operations to create complex expressions.
+```csharp
+var builder = ExpressionBuilder<Person>.ForCollections();
+            
+var result = builder
+    .ForCollection(x=>x.Pets)
+    .ForProperty(x => x.Name)
+    .OnlyIf(true)
+    .Compare(QueryOperation.StartsWith)
+    .WithAnyValue("Fi")
+    .AndAlso()
+    .Compare(QueryOperation.Contains)
+    .WithAnyValue("2")
+    .OrElse()
+    .Compare(QueryOperation.EndsWith)
+    .WithAnyValue("3")
+    .AndAlso()
+    .Compare(QueryOperation.Equals)
+    .WithAnyValue("Fido4")
+    .OrElse()
+    .Compare(QueryOperation.EndsWith)
+    .WithAnyValue("1")
+    .AsExpressionResult();
+
+result.IsSuccess.Should().BeTrue();
+
+Expression<Func<Person, bool>> stronglyTypedVersionExpression = x => x.Pets.Any(y=>y.Name.StartsWith("Fi") && y.Name.Contains("2") || y.Name.EndsWith("3") && y.Name.Equals("Fido4") || y.Name.EndsWith("1") );
+            
+result.Value.Should().BeEquivalentTo(stronglyTypedVersionExpression);
+            
+var list = people.AsQueryable().Where(result.Value);
+
+var list2 = people.AsQueryable().Where(stronglyTypedVersionExpression);
+
+list.Should().BeEquivalentTo(list2);
+
+```
+
+## Release Notes
+
+### v3.12.12
+- Added support for IEnumerables
+- Corrected the order of operations by implementing the necessary changes in the affected code.
+- Conducted comprehensive testing to verify the fix and ensure proper functionality.
+- With this correction, the package now executes operations according to the correct order, ensuring accurate results and expected behavior.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There is still more to come, but for now you can use it to create simple express
 
 QueryOperation are meant to be controlled by the developer as there isn't a easy way to narrow them by property type just yet.
 
-Now, IEnumerables expressions are supported.
+Now, IEnumerable expressions are supported.
 
 ## Simple usage in UnitTest form
 Visit the unit tests project to learn more


### PR DESCRIPTION
## Release Notes

### v3.13.12
- Added support for Collections allowing you to create expressions for multiple properties under the same collection.
  - In addition adds support for the following operations under collections:
    - AsAnyExpressionResult
    - AsAllExpressionResult
- Corrected the order of operations by implementing the necessary changes in the affected code.
- Conducted comprehensive testing to verify the fix and ensure proper functionality.
- With this correction, the package now executes operations according to the correct order, ensuring accurate results and expected behavior.